### PR TITLE
Handle 404 errors for unknown endpoints

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -2,6 +2,7 @@ from asgi_correlation_id import CorrelationIdMiddleware
 import sentry_sdk
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.dependencies.response import build_response
 from app.api.middleware.rate_limiting import RateLimitMiddleware
 from app.api.routers import (
@@ -73,6 +74,7 @@ app.include_router(reservation_router, prefix="/api")
 app.include_router(dashboard_router, prefix="/api")
 
 app.add_exception_handler(HTTPException, http_exception_handler)
+app.add_exception_handler(StarletteHTTPException, http_exception_handler)
 app.add_exception_handler(UnprocessableEntity, unprocessable_entity_error_422)
 app.add_exception_handler(NotFoundError, not_found_error_404)
 app.add_exception_handler(InvalidPassword, generic_error_400)

--- a/tests/api/test_not_found_endpoint.py
+++ b/tests/api/test_not_found_endpoint.py
@@ -1,0 +1,13 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_HOST"] = "mongomock://localhost"
+
+from app.application import app
+
+
+def test_nonexistent_endpoint_returns_not_found_message():
+    client = TestClient(app)
+    response = client.get("/api/nonexistent")
+    assert response.status_code == 404
+    assert response.json() == {"message": "Not Found"}


### PR DESCRIPTION
## Summary
- handle Starlette HTTPExceptions to return consistent message for unknown routes
- add test asserting 404 responses use standard message format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a11a31ff0c832aac8de43968fb48b3