### PR TITLE
Add company info to current user endpoint

### DIFF
--- a/app/api/routers/users/schemas.py
+++ b/app/api/routers/users/schemas.py
@@ -4,6 +4,7 @@ from pydantic import Field, ConfigDict
 
 from app.api.shared_schemas.responses import Response
 from app.crud.users.schemas import UserInDB
+from app.crud.companies.schemas import CompanyInDB
 
 EXAMPLE_USER = {
     "user_id": "id-123",
@@ -18,13 +19,32 @@ EXAMPLE_USER = {
     "updated_at": "2024-01-01T00:00:00Z",
 }
 
+EXAMPLE_COMPANY = {
+    "id": "cmp-123",
+    "name": "ACME",
+    "address_id": "add-123",
+    "phone_number": "9999-9999",
+    "ddd": "11",
+    "email": "info@acme.com",
+    "members": [],
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z",
+}
+
+
+class CurrentUser(UserInDB):
+    company: CompanyInDB | None = Field(default=None)
+
 
 class GetCurrentUserResponse(Response):
-    data: UserInDB | None = Field()
+    data: CurrentUser | None = Field()
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": {"message": "User found with success", "data": EXAMPLE_USER}
+            "example": {
+                "message": "User found with success",
+                "data": {**EXAMPLE_USER, "company": EXAMPLE_COMPANY},
+            }
         }
     )
 

--- a/tests/api/routers/users/test_endpoints.py
+++ b/tests/api/routers/users/test_endpoints.py
@@ -1,0 +1,69 @@
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routers.users import user_router
+from app.api.dependencies.auth import decode_jwt
+from app.api.composers.company_composite import company_composer
+from app.crud.users.schemas import UserInDB
+from app.crud.companies.schemas import CompanyInDB
+
+
+class TestUserEndpoints(unittest.TestCase):
+    def setUp(self) -> None:
+        self.user = UserInDB(
+            user_id="usr1",
+            email="u@t.com",
+            name="U",
+            nickname="u",
+            picture=None,
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+        self.company = CompanyInDB(
+            id="cmp1",
+            name="ACME",
+            address_id="add1",
+            phone_number="9999-9999",
+            ddd="11",
+            email="info@acme.com",
+            members=[],
+            created_at="2024-01-01T00:00:00Z",
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+        self.app = FastAPI()
+        self.app.include_router(user_router, prefix="/api")
+
+        async def override_decode_jwt():
+            return self.user
+
+        class CompanyServiceStub:
+            def __init__(self, company):
+                self.company = company
+
+            async def search_by_user(self, user_id: str):
+                return self.company
+
+        async def override_company_composer():
+            return CompanyServiceStub(self.company)
+
+        self.app.dependency_overrides[decode_jwt] = override_decode_jwt
+        self.app.dependency_overrides[company_composer] = override_company_composer
+
+        self.client = TestClient(self.app)
+
+    def tearDown(self) -> None:
+        self.app.dependency_overrides = {}
+
+    def test_get_current_user_returns_company(self):
+        resp = self.client.get("/api/users/me/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()["data"]
+        self.assertEqual(data["userId"], self.user.user_id)
+        self.assertEqual(data["company"]["id"], self.company.id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- return user's company schema in `GET /users/me`
- cover current user endpoint with test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1214362dc832ab7351287c897469f