### PR TITLE
Ensure company creator is owner and pluralize collections

### DIFF
--- a/app/api/routers/companies/command_routers.py
+++ b/app/api/routers/companies/command_routers.py
@@ -21,9 +21,13 @@ router = APIRouter(tags=["Companies"])
 )
 async def create_company(
     company: Company,
-    _: UserInDB = Depends(ensure_user_without_company),
+    user: UserInDB = Depends(ensure_user_without_company),
     company_services: CompanyServices = Depends(company_composer),
 ):
+    company.members = [
+        member for member in company.members if member.user_id != user.user_id
+    ]
+    company.members.append(CompanyMember(user_id=user.user_id, role="owner"))
     company_in_db = await company_services.create(company=company)
     return build_response(
         status_code=201, message="Company created with success", data=company_in_db

--- a/app/crud/companies/models.py
+++ b/app/crud/companies/models.py
@@ -20,3 +20,7 @@ class CompanyModel(BaseDocument):
     ddd = StringField(required=True)
     email = StringField(required=True)
     members = ListField(EmbeddedDocumentField(CompanyMember))
+
+    meta = {
+        "collection": "companies",
+    }

--- a/app/crud/customers/models.py
+++ b/app/crud/customers/models.py
@@ -15,6 +15,10 @@ class CustomerModel(BaseDocument):
     notes = StringField()
     company_id = StringField(required=True)
 
+    meta = {
+        "collection": "customers",
+    }
+
     def clean(self):
         if self.document and not (
             validate_cpf(self.document) or validate_cnpj(self.document)

--- a/app/crud/extractors/models.py
+++ b/app/crud/extractors/models.py
@@ -6,3 +6,7 @@ from app.core.models.base_document import BaseDocument
 class ExtractorModel(BaseDocument):
     brand = StringField(required=True)
     company_id = StringField(required=True)
+
+    meta = {
+        "collection": "extractors",
+    }

--- a/tests/api/routers/companies/test_endpoints.py
+++ b/tests/api/routers/companies/test_endpoints.py
@@ -105,7 +105,11 @@ class TestCompanyEndpoints(unittest.TestCase):
             "/api/companies", json=self._build_company_payload("NewCo")
         )
         self.assertEqual(resp.status_code, 201)
-        self.assertEqual(resp.json()["data"]["name"], "NewCo")
+        data = resp.json()["data"]
+        self.assertEqual(data["name"], "NewCo")
+        self.assertEqual(len(data["members"]), 1)
+        self.assertEqual(data["members"][0]["userId"], self.user.user_id)
+        self.assertEqual(data["members"][0]["role"], "owner")
 
     def test_get_company_by_id(self):
         resp = self.client.get(f"/api/companies/{self.company.id}")


### PR DESCRIPTION
## Summary
- Automatically assign the requesting user as owner when creating a company
- Use plural collection names without `_model` for company, customer and extractor documents
- Test company creation includes creator as owner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a12a648874832aace78d0df9bcae54