### PR TITLE
Add tests and Docker build to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/dev.txt
 
-      # - name: Test with pytest
-      #   run: |
-      #     pytest
+      - name: Test with pytest
+        run: |
+          pytest
 
-      # - name: Login to DockerHub
-      #   if: github.ref == 'refs/heads/dev'
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ vars.DOCKER_USERNAME }}
-      #     password: ${{ vars.DOCKER_TOKEN }}
-
-      # - name: Build, Barriil Club API
-      #   if: github.ref == 'refs/heads/dev'
-      #   run: |
-      #     docker build -t ${{ vars.DOCKER_USERNAME }}/${{ vars.MY_REPOSITORY_NAME }}:${{ github.sha }} .
-      #     docker push ${{ vars.DOCKER_USERNAME }}/${{ vars.MY_REPOSITORY_NAME }}:${{ github.sha }}
+      - name: Build Docker image
+        run: |
+          docker build -t barriil-club-api:${{ github.sha }} .


### PR DESCRIPTION
## Summary
- run `pytest` during CI to ensure tests pass
- build Docker image during CI to catch image build issues

## Testing
- `pytest` *(fails: 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2190b0b08832ab559c6cc918170e1