### PR TITLE
Add test and Docker build steps to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/dev.txt
 
-      # - name: Test with pytest
-      #   run: |
-      #     pytest
+      - name: Test with pytest
+        run: |
+          pytest
 
-      # - name: Login to DockerHub
-      #   if: github.ref == 'refs/heads/dev'
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ vars.DOCKER_USERNAME }}
-      #     password: ${{ vars.DOCKER_TOKEN }}
-
-      # - name: Build, Barriil Club API
-      #   if: github.ref == 'refs/heads/dev'
-      #   run: |
-      #     docker build -t ${{ vars.DOCKER_USERNAME }}/${{ vars.MY_REPOSITORY_NAME }}:${{ github.sha }} .
-      #     docker push ${{ vars.DOCKER_USERNAME }}/${{ vars.MY_REPOSITORY_NAME }}:${{ github.sha }}
+      - name: Build Docker image
+        run: |
+          docker build -t barriil-club-api .


### PR DESCRIPTION
## Summary
- run pytest during CI
- build the API Docker image to catch build errors

## Testing
- `pytest`
- `docker build -t barriil-club-api .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a223a53620832aa45af598cfeea3db