### PR TITLE
Restrict company membership management

### DIFF
--- a/app/api/dependencies/__init__.py
+++ b/app/api/dependencies/__init__.py
@@ -4,4 +4,5 @@ from .company import (
     ensure_user_without_company,
     require_user_company,
     require_company_member,
+    require_company_owner,
 )

--- a/app/api/routers/companies/command_routers.py
+++ b/app/api/routers/companies/command_routers.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.composers.company_composite import company_composer
 from app.api.dependencies import (
     build_response,
     ensure_user_without_company,
     require_company_member,
+    require_company_owner,
+    decode_jwt,
 )
 from app.api.shared_schemas.responses import MessageResponse
 from .schemas import CompanyResponse, SubscriptionResponse
@@ -79,11 +81,56 @@ async def add_member(
     company_id: str,
     member: CompanyMember,
     company_services: CompanyServices = Depends(company_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    _: CompanyInDB = Depends(require_company_owner),
 ):
     company_in_db = await company_services.add_member(company_id=company_id, member=member)
     return build_response(
         status_code=200, message="Member added with success", data=company_in_db
+    )
+
+
+@router.delete(
+    "/companies/{company_id}/members/me",
+    responses={200: {"model": CompanyResponse}, 403: {"model": MessageResponse}},
+)
+async def leave_company(
+    company_id: str,
+    company_services: CompanyServices = Depends(company_composer),
+    current_user: UserInDB = Depends(decode_jwt),
+    company: CompanyInDB = Depends(require_company_member),
+):
+    if any(
+        member.user_id == current_user.user_id and member.role == "owner"
+        for member in company.members
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner cannot leave the company",
+        )
+
+    company_in_db = await company_services.remove_member(
+        company_id=company_id, user_id=current_user.user_id
+    )
+    return build_response(
+        status_code=200, message="Member removed with success", data=company_in_db
+    )
+
+
+@router.delete(
+    "/companies/{company_id}/members/{user_id}",
+    responses={200: {"model": CompanyResponse}, 404: {"model": MessageResponse}},
+)
+async def remove_member(
+    company_id: str,
+    user_id: str,
+    company_services: CompanyServices = Depends(company_composer),
+    _: CompanyInDB = Depends(require_company_owner),
+):
+    company_in_db = await company_services.remove_member(
+        company_id=company_id, user_id=user_id
+    )
+    return build_response(
+        status_code=200, message="Member removed with success", data=company_in_db
     )
 
 

--- a/app/crud/companies/services.py
+++ b/app/crud/companies/services.py
@@ -45,6 +45,9 @@ class CompanyServices:
     async def add_member(self, company_id: str, member: CompanyMember) -> CompanyInDB:
         return await self.__repository.add_member(company_id=company_id, member=member)
 
+    async def remove_member(self, company_id: str, user_id: str) -> CompanyInDB:
+        return await self.__repository.remove_member(company_id=company_id, user_id=user_id)
+
     async def search_by_user(self, user_id: str) -> CompanyInDB:
         return await self.__repository.select_by_user(user_id=user_id)
 

--- a/tests/crud/companies/test_repository.py
+++ b/tests/crud/companies/test_repository.py
@@ -111,6 +111,22 @@ class TestCompanyRepository(unittest.TestCase):
         with self.assertRaises(UnprocessableEntity):
             asyncio.run(repository.add_member(c2.id, member))
 
+    def test_remove_member(self):
+        doc = CompanyModel(**self._build_company().model_dump())
+        doc.save()
+        repository = CompanyRepository()
+        member = CompanyMember(user_id="usr1", role="owner")
+        asyncio.run(repository.add_member(doc.id, member))
+        updated = asyncio.run(repository.remove_member(doc.id, "usr1"))
+        self.assertEqual(len(updated.members), 0)
+
+    def test_remove_member_not_found(self):
+        doc = CompanyModel(**self._build_company().model_dump())
+        doc.save()
+        repository = CompanyRepository()
+        with self.assertRaises(NotFoundError):
+            asyncio.run(repository.remove_member(doc.id, "usr1"))
+
     def test_select_by_user(self):
         doc = CompanyModel(**self._build_company().model_dump())
         doc.save()

--- a/tests/crud/companies/test_services.py
+++ b/tests/crud/companies/test_services.py
@@ -141,6 +141,23 @@ class TestCompanyServices(unittest.TestCase):
         with self.assertRaises(UnprocessableEntity):
             asyncio.run(self.services.add_member(c2.id, member))
 
+    def test_remove_member(self):
+        doc = CompanyModel(**self._build_company().model_dump())
+        doc.save()
+        owner = CompanyMember(user_id="usr1", role="owner")
+        member = CompanyMember(user_id="usr2", role="member")
+        asyncio.run(self.services.add_member(doc.id, owner))
+        asyncio.run(self.services.add_member(doc.id, member))
+        updated = asyncio.run(self.services.remove_member(doc.id, "usr2"))
+        self.assertEqual(len(updated.members), 1)
+        self.assertEqual(updated.members[0].user_id, "usr1")
+
+    def test_remove_member_not_found(self):
+        doc = CompanyModel(**self._build_company().model_dump())
+        doc.save()
+        with self.assertRaises(NotFoundError):
+            asyncio.run(self.services.remove_member(doc.id, "usr1"))
+
     def test_search_by_user(self):
         doc = CompanyModel(**self._build_company().model_dump())
         doc.members.append(CompanyMemberModel(user_id="usr1", role="owner"))


### PR DESCRIPTION
## Summary
- allow only company owners to add or remove members
- add endpoint for members to leave their company
- cover membership management with unit tests

## Testing
- `pytest tests/api/routers/companies/test_endpoints.py -q`
- `pytest tests/crud/companies/test_repository.py -q`
- `pytest tests/crud/companies/test_services.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a29e2c9cb4832abf30d495b5386f1e