### PR TITLE
Allow recreating cylinder number after deletion

### DIFF
--- a/app/crud/cylinders/models.py
+++ b/app/crud/cylinders/models.py
@@ -8,7 +8,7 @@ from .schemas import CylinderStatus
 class CylinderModel(BaseDocument):
     brand = StringField(required=True)
     weight_kg = DecimalField(required=True, precision=2)
-    number = StringField(required=True, unique=True)
+    number = StringField(required=True)
     status = StringField(required=True, choices=[s.value for s in CylinderStatus])
     notes = StringField()
     company_id = StringField(required=True)

--- a/app/crud/cylinders/repositories.py
+++ b/app/crud/cylinders/repositories.py
@@ -20,6 +20,16 @@ class CylinderRepository(Repository):
 
     async def create(self, cylinder: Cylinder) -> CylinderInDB:
         try:
+            exists = CylinderModel.objects(
+                number=cylinder.number,
+                company_id=cylinder.company_id,
+                is_active=True,
+            ).first()
+            if exists:
+                raise NotFoundError(
+                    message=f"Cylinder #{cylinder.number} already exists"
+                )
+
             json = jsonable_encoder(cylinder.model_dump())
             model = CylinderModel(
                 is_active=True,

--- a/tests/crud/cylinders/test_repository.py
+++ b/tests/crud/cylinders/test_repository.py
@@ -81,6 +81,25 @@ class TestCylinderRepository(unittest.TestCase):
         with self.assertRaises(NotFoundError):
             asyncio.run(repository.delete_by_id("invalid", "com1"))
 
+    def test_create_cylinder_duplicate_number_active(self):
+        repository = CylinderRepository()
+        cylinder = self._build_cylinder()
+        asyncio.run(repository.create(cylinder))
+        with self.assertRaises(NotFoundError):
+            asyncio.run(repository.create(cylinder))
+
+    def test_create_cylinder_after_soft_delete(self):
+        repository = CylinderRepository()
+        cylinder = self._build_cylinder()
+        first = asyncio.run(repository.create(cylinder))
+        asyncio.run(repository.delete_by_id(first.id, first.company_id))
+        second = asyncio.run(repository.create(cylinder))
+        self.assertEqual(second.number, cylinder.number)
+        self.assertNotEqual(first.id, second.id)
+        self.assertEqual(
+            CylinderModel.objects(number=cylinder.number, is_active=True).count(), 1
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow creating a cylinder with the same number after soft deletion
- cover duplicate/soft deletion scenarios with repository tests

## Testing
- `pytest tests/crud/cylinders/test_repository.py -q`
- `pytest tests/crud/cylinders/test_services.py -q`
- `pytest tests/api/routers/cylinders/test_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2ab1fa600832ab67c3dcdd9d6f73c