### PR TITLE
Use authenticated company for equipment operations

### DIFF
--- a/app/api/routers/beer_dispensers/query_routers.py
+++ b/app/api/routers/beer_dispensers/query_routers.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 
 from app.api.composers.beer_dispenser_composite import beer_dispenser_composer
-from app.api.dependencies import build_response, require_company_member
+from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
 from .schemas import BeerDispenserResponse, BeerDispenserListResponse
 from app.crud.beer_dispensers import BeerDispenserServices
@@ -16,11 +16,12 @@ router = APIRouter(tags=["Beer Dispensers"])
 )
 async def get_beer_dispenser_by_id(
     dispenser_id: str,
-    company_id: str,
     services: BeerDispenserServices = Depends(beer_dispenser_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    dispenser_in_db = await services.search_by_id(id=dispenser_id, company_id=company_id)
+    dispenser_in_db = await services.search_by_id(
+        id=dispenser_id, company_id=str(company.id)
+    )
     return build_response(
         status_code=200, message="Beer dispenser found with success", data=dispenser_in_db
     )
@@ -31,11 +32,10 @@ async def get_beer_dispenser_by_id(
     responses={200: {"model": BeerDispenserListResponse}, 204: {"description": "No Content"}},
 )
 async def get_beer_dispensers(
-    company_id: str,
     services: BeerDispenserServices = Depends(beer_dispenser_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    dispensers = await services.search_all(company_id=company_id)
+    dispensers = await services.search_all(company_id=str(company.id))
     if dispensers:
         return build_response(
             status_code=200,

--- a/app/api/routers/extractors/query_routers.py
+++ b/app/api/routers/extractors/query_routers.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 
 from app.api.composers.extractor_composite import extractor_composer
-from app.api.dependencies import build_response, require_company_member
+from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
 from .schemas import ExtractorResponse, ExtractorListResponse
 from app.crud.extractors import ExtractorServices
@@ -16,12 +16,11 @@ router = APIRouter(tags=["Extractors"])
 )
 async def get_extractor_by_id(
     extractor_id: str,
-    company_id: str,
     extractor_services: ExtractorServices = Depends(extractor_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
     extractor_in_db = await extractor_services.search_by_id(
-        id=extractor_id, company_id=company_id
+        id=extractor_id, company_id=str(company.id)
     )
     return build_response(
         status_code=200, message="Extractor found with success", data=extractor_in_db
@@ -33,11 +32,10 @@ async def get_extractor_by_id(
     responses={200: {"model": ExtractorListResponse}, 204: {"description": "No Content"}},
 )
 async def get_extractors(
-    company_id: str,
     extractor_services: ExtractorServices = Depends(extractor_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    extractors = await extractor_services.search_all(company_id=company_id)
+    extractors = await extractor_services.search_all(company_id=str(company.id))
     if extractors:
         return build_response(
             status_code=200, message="Extractors found with success", data=extractors

--- a/app/api/routers/pressure_gauges/query_routers.py
+++ b/app/api/routers/pressure_gauges/query_routers.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Response
 
 from app.api.composers.pressure_gauge_composite import pressure_gauge_composer
-from app.api.dependencies import build_response, require_company_member
+from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
 from .schemas import PressureGaugeResponse, PressureGaugeListResponse
 from app.crud.pressure_gauges import PressureGaugeServices
@@ -16,11 +16,10 @@ router = APIRouter(tags=["Pressure Gauges"])
 )
 async def get_pressure_gauge_by_id(
     gauge_id: str,
-    company_id: str,
     services: PressureGaugeServices = Depends(pressure_gauge_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    gauge_in_db = await services.search_by_id(id=gauge_id, company_id=company_id)
+    gauge_in_db = await services.search_by_id(id=gauge_id, company_id=str(company.id))
     return build_response(
         status_code=200,
         message="Pressure gauge found with success",
@@ -33,11 +32,10 @@ async def get_pressure_gauge_by_id(
     responses={200: {"model": PressureGaugeListResponse}, 204: {"description": "No Content"}},
 )
 async def get_pressure_gauges(
-    company_id: str,
     services: PressureGaugeServices = Depends(pressure_gauge_composer),
-    _: CompanyInDB = Depends(require_company_member),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    gauges = await services.search_all(company_id=company_id)
+    gauges = await services.search_all(company_id=str(company.id))
     if gauges:
         return build_response(
             status_code=200,

--- a/app/crud/beer_dispensers/repositories.py
+++ b/app/crud/beer_dispensers/repositories.py
@@ -18,13 +18,14 @@ class BeerDispenserRepository(Repository):
     def __init__(self) -> None:
         super().__init__()
 
-    async def create(self, dispenser: BeerDispenser) -> BeerDispenserInDB:
+    async def create(self, dispenser: BeerDispenser, company_id: str) -> BeerDispenserInDB:
         try:
             json = jsonable_encoder(dispenser.model_dump())
             model = BeerDispenserModel(
                 is_active=True,
                 created_at=UTCDateTime.now(),
                 updated_at=UTCDateTime.now(),
+                company_id=company_id,
                 **json,
             )
             model.save()

--- a/app/crud/beer_dispensers/schemas.py
+++ b/app/crud/beer_dispensers/schemas.py
@@ -24,7 +24,6 @@ class BeerDispenser(GenericModel):
     voltage: Voltage | None = Field(default=None, example=Voltage.V110)
     status: DispenserStatus = Field(example=DispenserStatus.ACTIVE)
     notes: str | None = Field(default=None, example="notes")
-    company_id: str = Field(example="com_123")
 
 
 class BeerDispenserInDB(DatabaseModel):

--- a/app/crud/beer_dispensers/services.py
+++ b/app/crud/beer_dispensers/services.py
@@ -8,8 +8,8 @@ class BeerDispenserServices:
     def __init__(self, repository: BeerDispenserRepository) -> None:
         self.__repository = repository
 
-    async def create(self, dispenser: BeerDispenser) -> BeerDispenserInDB:
-        return await self.__repository.create(dispenser=dispenser)
+    async def create(self, dispenser: BeerDispenser, company_id: str) -> BeerDispenserInDB:
+        return await self.__repository.create(dispenser=dispenser, company_id=company_id)
 
     async def update(
         self, id: str, company_id: str, dispenser: UpdateBeerDispenser

--- a/app/crud/extractors/repositories.py
+++ b/app/crud/extractors/repositories.py
@@ -18,13 +18,14 @@ class ExtractorRepository(Repository):
     def __init__(self) -> None:
         super().__init__()
 
-    async def create(self, extractor: Extractor) -> ExtractorInDB:
+    async def create(self, extractor: Extractor, company_id: str) -> ExtractorInDB:
         try:
             json = jsonable_encoder(extractor.model_dump())
             extractor_model = ExtractorModel(
                 is_active=True,
                 created_at=UTCDateTime.now(),
                 updated_at=UTCDateTime.now(),
+                company_id=company_id,
                 **json,
             )
             extractor_model.save()

--- a/app/crud/extractors/schemas.py
+++ b/app/crud/extractors/schemas.py
@@ -6,7 +6,6 @@ from app.core.models.base_model import DatabaseModel
 
 class Extractor(GenericModel):
     brand: str = Field(example="Acme")
-    company_id: str = Field(example="com_123")
 
 
 class ExtractorInDB(DatabaseModel):

--- a/app/crud/extractors/services.py
+++ b/app/crud/extractors/services.py
@@ -8,8 +8,8 @@ class ExtractorServices:
     def __init__(self, extractor_repository: ExtractorRepository) -> None:
         self.__repository = extractor_repository
 
-    async def create(self, extractor: Extractor) -> ExtractorInDB:
-        return await self.__repository.create(extractor=extractor)
+    async def create(self, extractor: Extractor, company_id: str) -> ExtractorInDB:
+        return await self.__repository.create(extractor=extractor, company_id=company_id)
 
     async def update(
         self, id: str, company_id: str, extractor: UpdateExtractor

--- a/app/crud/pressure_gauges/repositories.py
+++ b/app/crud/pressure_gauges/repositories.py
@@ -18,13 +18,14 @@ class PressureGaugeRepository(Repository):
     def __init__(self) -> None:
         super().__init__()
 
-    async def create(self, gauge: PressureGauge) -> PressureGaugeInDB:
+    async def create(self, gauge: PressureGauge, company_id: str) -> PressureGaugeInDB:
         try:
             json = jsonable_encoder(gauge.model_dump())
             model = PressureGaugeModel(
                 is_active=True,
                 created_at=UTCDateTime.now(),
                 updated_at=UTCDateTime.now(),
+                company_id=company_id,
                 **json,
             )
             model.save()

--- a/app/crud/pressure_gauges/schemas.py
+++ b/app/crud/pressure_gauges/schemas.py
@@ -25,7 +25,6 @@ class PressureGauge(GenericModel):
     last_calibration_date: date | None = Field(default=None, example="2024-01-01")
     status: PressureGaugeStatus = Field(example=PressureGaugeStatus.ACTIVE)
     notes: str | None = Field(default=None, example="notes")
-    company_id: str = Field(example="com_123")
 
 
 class PressureGaugeInDB(DatabaseModel):

--- a/app/crud/pressure_gauges/services.py
+++ b/app/crud/pressure_gauges/services.py
@@ -8,8 +8,8 @@ class PressureGaugeServices:
     def __init__(self, repository: PressureGaugeRepository) -> None:
         self.__repository = repository
 
-    async def create(self, gauge: PressureGauge) -> PressureGaugeInDB:
-        return await self.__repository.create(gauge=gauge)
+    async def create(self, gauge: PressureGauge, company_id: str) -> PressureGaugeInDB:
+        return await self.__repository.create(gauge=gauge, company_id=company_id)
 
     async def update(
         self, id: str, company_id: str, gauge: UpdatePressureGauge

--- a/tests/api/routers/pressure_gauges/test_endpoints.py
+++ b/tests/api/routers/pressure_gauges/test_endpoints.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 from mongoengine import connect, disconnect
 
 from app.api.routers.pressure_gauges import pressure_gauge_router
-from app.api.dependencies.company import require_company_member, require_user_company
+from app.api.dependencies.company import require_user_company
 from app.api.composers.pressure_gauge_composite import pressure_gauge_composer
 from app.crud.companies.repositories import CompanyRepository
 from app.crud.companies.services import CompanyServices
@@ -42,17 +42,12 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
         async def override_require_user_company():
             return self.company
 
-        async def override_require_company_member(company_id: str):
-            return self.company
 
         async def override_gauge_composer():
             return self.services
 
         self.app.dependency_overrides[require_user_company] = (
             override_require_user_company
-        )
-        self.app.dependency_overrides[require_company_member] = (
-            override_require_company_member
         )
         self.app.dependency_overrides[pressure_gauge_composer] = override_gauge_composer
         self.client = TestClient(self.app)
@@ -83,9 +78,10 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
             last_calibration_date=None,
             status=PressureGaugeStatus.ACTIVE,
             notes="",
-            company_id=str(self.company.id),
         )
-        self.gauge = asyncio.run(self.services.create(gauge))
+        self.gauge = asyncio.run(
+            self.services.create(gauge, company_id=str(self.company.id))
+        )
 
     def tearDown(self) -> None:
         self.app.dependency_overrides = {}
@@ -97,7 +93,6 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
             "type": "ANALOG",
             "serialNumber": "SN2",
             "status": "ACTIVE",
-            "companyId": str(self.company.id),
         }
 
     def test_create_gauge_endpoint(self):
@@ -107,23 +102,19 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
 
     def test_get_gauge_by_id(self):
         resp = self.client.get(
-            f"/api/pressure-gauges/{self.gauge.id}",
-            params={"company_id": str(self.company.id)},
+            f"/api/pressure-gauges/{self.gauge.id}"
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["data"]["id"], self.gauge.id)
 
     def test_list_gauges(self):
-        resp = self.client.get(
-            "/api/pressure-gauges", params={"company_id": str(self.company.id)}
-        )
+        resp = self.client.get("/api/pressure-gauges")
         self.assertEqual(resp.status_code, 200)
         self.assertGreaterEqual(len(resp.json()["data"]), 1)
 
     def test_update_gauge_endpoint(self):
         resp = self.client.put(
             f"/api/pressure-gauges/{self.gauge.id}",
-            params={"company_id": str(self.company.id)},
             json={"brand": "Updated"},
         )
         self.assertEqual(resp.status_code, 200)
@@ -131,15 +122,14 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
 
     def test_delete_gauge_endpoint(self):
         resp = self.client.delete(
-            f"/api/pressure-gauges/{self.gauge.id}",
-            params={"company_id": str(self.company.id)},
+            f"/api/pressure-gauges/{self.gauge.id}"
         )
         self.assertEqual(resp.status_code, 200)
         with self.assertRaises(NotFoundError):
             asyncio.run(self.services.search_by_id(self.gauge.id, str(self.company.id)))
 
     def test_create_gauge_returns_400_when_not_created(self):
-        async def fake_create(gauge):
+        async def fake_create(gauge, company_id):
             return None
 
         self.services.create = fake_create
@@ -153,7 +143,6 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
         self.services.update = fake_update
         resp = self.client.put(
             f"/api/pressure-gauges/{self.gauge.id}",
-            params={"company_id": str(self.company.id)},
             json={"brand": "Fail"},
         )
         self.assertEqual(resp.status_code, 400)
@@ -164,8 +153,7 @@ class TestPressureGaugeEndpoints(unittest.TestCase):
 
         self.services.delete_by_id = fake_delete
         resp = self.client.delete(
-            f"/api/pressure-gauges/{self.gauge.id}",
-            params={"company_id": str(self.company.id)},
+            f"/api/pressure-gauges/{self.gauge.id}"
         )
         self.assertEqual(resp.status_code, 400)
 

--- a/tests/api/routers/reservations/test_endpoints.py
+++ b/tests/api/routers/reservations/test_endpoints.py
@@ -123,8 +123,8 @@ class TestReservationEndpoints(unittest.TestCase):
                     voltage=Voltage.V110,
                     status=DispenserStatus.ACTIVE,
                     notes="",
-                    company_id=str(self.company.id),
-                )
+                ),
+                company_id=str(self.company.id),
             )
         )
 
@@ -148,7 +148,8 @@ class TestReservationEndpoints(unittest.TestCase):
 
         self.extractor = asyncio.run(
             self.extractor_services.create(
-                Extractor(brand="Acme", company_id=str(self.company.id))
+                Extractor(brand="Acme"),
+                company_id=str(self.company.id),
             )
         )
 
@@ -158,8 +159,8 @@ class TestReservationEndpoints(unittest.TestCase):
                     brand="Acme",
                     type=PressureGaugeType.ANALOG,
                     status=PressureGaugeStatus.ACTIVE,
-                    company_id=str(self.company.id),
-                )
+                ),
+                company_id=str(self.company.id),
             )
         )
 
@@ -216,8 +217,8 @@ class TestReservationEndpoints(unittest.TestCase):
                     voltage=Voltage.V110,
                     status=DispenserStatus.ACTIVE,
                     notes="",
-                    company_id=str(self.company.id),
-                )
+                ),
+                company_id=str(self.company.id),
             )
         )
         payload = self._payload()
@@ -321,8 +322,8 @@ class TestReservationEndpoints(unittest.TestCase):
                     voltage=Voltage.V110,
                     status=DispenserStatus.ACTIVE,
                     notes="",
-                    company_id=str(self.company.id),
-                )
+                ),
+                company_id=str(self.company.id),
             )
         )
         payload = self._payload()

--- a/tests/crud/beer_dispensers/test_repository.py
+++ b/tests/crud/beer_dispensers/test_repository.py
@@ -21,7 +21,7 @@ class TestBeerDispenserRepository(unittest.TestCase):
     def tearDown(self) -> None:
         disconnect()
 
-    def _build_dispenser(self, brand: str = "Acme", company_id: str = "com1") -> BeerDispenser:
+    def _build_dispenser(self, brand: str = "Acme") -> BeerDispenser:
         return BeerDispenser(
             brand=brand,
             model="X1",
@@ -30,18 +30,17 @@ class TestBeerDispenserRepository(unittest.TestCase):
             voltage=Voltage.V110,
             status=DispenserStatus.ACTIVE,
             notes="",
-            company_id=company_id,
         )
 
     def test_create_dispenser(self):
         repository = BeerDispenserRepository()
         dispenser = self._build_dispenser()
-        result = asyncio.run(repository.create(dispenser))
+        result = asyncio.run(repository.create(dispenser, "com1"))
         self.assertEqual(result.brand, "Acme")
         self.assertEqual(BeerDispenserModel.objects.count(), 1)
 
     def test_select_by_id_found(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         repository = BeerDispenserRepository()
         res = asyncio.run(repository.select_by_id(doc.id, doc.company_id))
@@ -53,14 +52,14 @@ class TestBeerDispenserRepository(unittest.TestCase):
             asyncio.run(repository.select_by_id("invalid", "com1"))
 
     def test_select_all(self):
-        BeerDispenserModel(**self._build_dispenser("A").model_dump()).save()
-        BeerDispenserModel(**self._build_dispenser("B").model_dump()).save()
+        BeerDispenserModel(**self._build_dispenser("A").model_dump(), company_id="com1").save()
+        BeerDispenserModel(**self._build_dispenser("B").model_dump(), company_id="com1").save()
         repository = BeerDispenserRepository()
         res = asyncio.run(repository.select_all("com1"))
         self.assertEqual(len(res), 2)
 
     def test_update_dispenser(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         repository = BeerDispenserRepository()
         updated = asyncio.run(
@@ -69,7 +68,7 @@ class TestBeerDispenserRepository(unittest.TestCase):
         self.assertEqual(updated.brand, "New")
 
     def test_delete_dispenser(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         repository = BeerDispenserRepository()
         result = asyncio.run(repository.delete_by_id(doc.id, doc.company_id))

--- a/tests/crud/beer_dispensers/test_services.py
+++ b/tests/crud/beer_dispensers/test_services.py
@@ -29,7 +29,7 @@ class TestBeerDispenserServices(unittest.TestCase):
     def tearDown(self) -> None:
         disconnect()
 
-    def _build_dispenser(self, brand: str = "Acme", company_id: str = "com1") -> BeerDispenser:
+    def _build_dispenser(self, brand: str = "Acme") -> BeerDispenser:
         return BeerDispenser(
             brand=brand,
             model="X1",
@@ -38,26 +38,25 @@ class TestBeerDispenserServices(unittest.TestCase):
             voltage=Voltage.V110,
             status=DispenserStatus.ACTIVE,
             notes="",
-            company_id=company_id,
         )
 
     def test_create_dispenser(self):
-        result = asyncio.run(self.services.create(self._build_dispenser()))
+        result = asyncio.run(self.services.create(self._build_dispenser(), "com1"))
         self.assertEqual(result.brand, "Acme")
 
     def test_search_by_id(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         res = asyncio.run(self.services.search_by_id(doc.id, doc.company_id))
         self.assertEqual(res.id, doc.id)
 
     def test_search_all(self):
-        BeerDispenserModel(**self._build_dispenser().model_dump()).save()
+        BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1").save()
         res = asyncio.run(self.services.search_all("com1"))
         self.assertEqual(len(res), 1)
 
     def test_update_dispenser(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         updated = asyncio.run(
             self.services.update(
@@ -67,7 +66,7 @@ class TestBeerDispenserServices(unittest.TestCase):
         self.assertEqual(updated.brand, "New")
 
     def test_delete_dispenser(self):
-        doc = BeerDispenserModel(**self._build_dispenser().model_dump())
+        doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")
         doc.save()
         res = asyncio.run(self.services.delete_by_id(doc.id, doc.company_id))
         self.assertEqual(res.id, doc.id)

--- a/tests/crud/extractors/test_repository.py
+++ b/tests/crud/extractors/test_repository.py
@@ -21,40 +21,40 @@ class TestExtractorRepository(unittest.TestCase):
     def tearDown(self) -> None:
         disconnect()
 
-    def _build_extractor(self, brand: str = "BrandX", company_id: str = "com1") -> Extractor:
-        return Extractor(brand=brand, company_id=company_id)
+    def _build_extractor(self, brand: str = "BrandX") -> Extractor:
+        return Extractor(brand=brand)
 
     def test_create_extractor(self):
         repository = ExtractorRepository()
         extractor = self._build_extractor()
-        result = asyncio.run(repository.create(extractor))
+        result = asyncio.run(repository.create(extractor, "com1"))
         self.assertEqual(result.brand, "BrandX")
         self.assertEqual(ExtractorModel.objects.count(), 1)
 
     def test_select_by_id_found(self):
-        doc = ExtractorModel(**self._build_extractor().model_dump())
+        doc = ExtractorModel(**self._build_extractor().model_dump(), company_id="com1")
         doc.save()
         repository = ExtractorRepository()
         res = asyncio.run(repository.select_by_id(doc.id, "com1"))
         self.assertEqual(res.id, doc.id)
 
     def test_select_by_id_wrong_company(self):
-        doc = ExtractorModel(**self._build_extractor().model_dump())
+        doc = ExtractorModel(**self._build_extractor().model_dump(), company_id="com1")
         doc.save()
         repository = ExtractorRepository()
         with self.assertRaises(NotFoundError):
             asyncio.run(repository.select_by_id(doc.id, "other"))
 
     def test_select_all(self):
-        ExtractorModel(**self._build_extractor("A", "com1").model_dump()).save()
-        ExtractorModel(**self._build_extractor("B", "com1").model_dump()).save()
-        ExtractorModel(**self._build_extractor("C", "com2").model_dump()).save()
+        ExtractorModel(**self._build_extractor("A").model_dump(), company_id="com1").save()
+        ExtractorModel(**self._build_extractor("B").model_dump(), company_id="com1").save()
+        ExtractorModel(**self._build_extractor("C").model_dump(), company_id="com2").save()
         repository = ExtractorRepository()
         res = asyncio.run(repository.select_all("com1"))
         self.assertEqual(len(res), 2)
 
     def test_update_extractor(self):
-        doc = ExtractorModel(**self._build_extractor("Old", "com1").model_dump())
+        doc = ExtractorModel(**self._build_extractor("Old").model_dump(), company_id="com1")
         doc.save()
         repository = ExtractorRepository()
         updated = asyncio.run(
@@ -70,7 +70,7 @@ class TestExtractorRepository(unittest.TestCase):
             )
 
     def test_delete_extractor(self):
-        doc = ExtractorModel(**self._build_extractor("Del", "com1").model_dump())
+        doc = ExtractorModel(**self._build_extractor("Del").model_dump(), company_id="com1")
         doc.save()
         repository = ExtractorRepository()
         result = asyncio.run(repository.delete_by_id(doc.id, "com1"))

--- a/tests/crud/extractors/test_services.py
+++ b/tests/crud/extractors/test_services.py
@@ -24,17 +24,17 @@ class TestExtractorServices(unittest.TestCase):
     def tearDown(self) -> None:
         disconnect()
 
-    def _build_extractor(self, brand: str = "BrandX", company_id: str = "com1") -> Extractor:
-        return Extractor(brand=brand, company_id=company_id)
+    def _build_extractor(self, brand: str = "BrandX") -> Extractor:
+        return Extractor(brand=brand)
 
     def test_create_extractor(self):
         extractor = self._build_extractor()
-        result = asyncio.run(self.services.create(extractor))
+        result = asyncio.run(self.services.create(extractor, "com1"))
         self.assertEqual(result.brand, "BrandX")
         self.assertEqual(ExtractorModel.objects.count(), 1)
 
     def test_search_by_id(self):
-        doc = ExtractorModel(**self._build_extractor().model_dump())
+        doc = ExtractorModel(**self._build_extractor().model_dump(), company_id="com1")
         doc.save()
         res = asyncio.run(self.services.search_by_id(doc.id, "com1"))
         self.assertEqual(res.id, doc.id)
@@ -44,14 +44,14 @@ class TestExtractorServices(unittest.TestCase):
             asyncio.run(self.services.search_by_id("invalid", "com1"))
 
     def test_search_all(self):
-        ExtractorModel(**self._build_extractor("A", "com1").model_dump()).save()
-        ExtractorModel(**self._build_extractor("B", "com1").model_dump()).save()
-        ExtractorModel(**self._build_extractor("C", "com2").model_dump()).save()
+        ExtractorModel(**self._build_extractor("A").model_dump(), company_id="com1").save()
+        ExtractorModel(**self._build_extractor("B").model_dump(), company_id="com1").save()
+        ExtractorModel(**self._build_extractor("C").model_dump(), company_id="com2").save()
         res = asyncio.run(self.services.search_all("com1"))
         self.assertEqual(len(res), 2)
 
     def test_update_extractor(self):
-        doc = ExtractorModel(**self._build_extractor("Old", "com1").model_dump())
+        doc = ExtractorModel(**self._build_extractor("Old").model_dump(), company_id="com1")
         doc.save()
         updated = asyncio.run(
             self.services.update(doc.id, "com1", UpdateExtractor(brand="New"))
@@ -65,7 +65,7 @@ class TestExtractorServices(unittest.TestCase):
             )
 
     def test_delete_extractor(self):
-        doc = ExtractorModel(**self._build_extractor("Del", "com1").model_dump())
+        doc = ExtractorModel(**self._build_extractor("Del").model_dump(), company_id="com1")
         doc.save()
         result = asyncio.run(self.services.delete_by_id(doc.id, "com1"))
         self.assertEqual(result.id, doc.id)

--- a/tests/crud/pressure_gauges/test_services.py
+++ b/tests/crud/pressure_gauges/test_services.py
@@ -29,7 +29,7 @@ class TestPressureGaugeServices(unittest.TestCase):
     def tearDown(self) -> None:
         disconnect()
 
-    def _build_gauge(self, brand: str = "Acme", company_id: str = "com1") -> PressureGauge:
+    def _build_gauge(self, brand: str = "Acme") -> PressureGauge:
         return PressureGauge(
             brand=brand,
             type=PressureGaugeType.ANALOG,
@@ -37,26 +37,25 @@ class TestPressureGaugeServices(unittest.TestCase):
             last_calibration_date=None,
             status=PressureGaugeStatus.ACTIVE,
             notes="",
-            company_id=company_id,
         )
 
     def test_create_gauge(self):
-        result = asyncio.run(self.services.create(self._build_gauge()))
+        result = asyncio.run(self.services.create(self._build_gauge(), "com1"))
         self.assertEqual(result.brand, "Acme")
 
     def test_search_by_id(self):
-        doc = PressureGaugeModel(**self._build_gauge().model_dump())
+        doc = PressureGaugeModel(**self._build_gauge().model_dump(), company_id="com1")
         doc.save()
         res = asyncio.run(self.services.search_by_id(doc.id, doc.company_id))
         self.assertEqual(res.id, doc.id)
 
     def test_search_all(self):
-        PressureGaugeModel(**self._build_gauge().model_dump()).save()
+        PressureGaugeModel(**self._build_gauge().model_dump(), company_id="com1").save()
         res = asyncio.run(self.services.search_all("com1"))
         self.assertEqual(len(res), 1)
 
     def test_update_gauge(self):
-        doc = PressureGaugeModel(**self._build_gauge().model_dump())
+        doc = PressureGaugeModel(**self._build_gauge().model_dump(), company_id="com1")
         doc.save()
         updated = asyncio.run(
             self.services.update(
@@ -66,7 +65,7 @@ class TestPressureGaugeServices(unittest.TestCase):
         self.assertEqual(updated.brand, "New")
 
     def test_delete_gauge(self):
-        doc = PressureGaugeModel(**self._build_gauge().model_dump())
+        doc = PressureGaugeModel(**self._build_gauge().model_dump(), company_id="com1")
         doc.save()
         res = asyncio.run(self.services.delete_by_id(doc.id, doc.company_id))
         self.assertEqual(res.id, doc.id)


### PR DESCRIPTION
## Summary
- fetch company from user context instead of request for pressure gauges, beer dispensers and extractors
- update services and repositories to accept company id internally
- adjust unit tests to reflect new company handling

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68a330afec9c832aae65073d6c3c6501