### PR TITLE
Fetch address by ZIP via ViaCEP

### DIFF
--- a/app/api/routers/addresses/query_routers.py
+++ b/app/api/routers/addresses/query_routers.py
@@ -52,9 +52,9 @@ async def get_address_by_zip_code(
     company: CompanyInDB = Depends(require_user_company),
     address_services: AddressServices = Depends(address_composer),
 ):
-    address_in_db = await address_services.search_by_zip_code(
+    address = await address_services.search_by_zip_code(
         zip_code=zip_code, company_id=str(company.id)
     )
     return build_response(
-        status_code=200, message="Address found with success", data=address_in_db
+        status_code=200, message="Address found with success", data=address
     )

--- a/app/api/routers/addresses/schemas.py
+++ b/app/api/routers/addresses/schemas.py
@@ -3,7 +3,7 @@ from typing import List
 from pydantic import Field, ConfigDict
 
 from app.api.shared_schemas.responses import Response
-from app.crud.addresses.schemas import AddressInDB
+from app.crud.addresses.schemas import Address, AddressInDB
 
 EXAMPLE_ADDRESS = {
     "id": "add_12345678",
@@ -22,7 +22,7 @@ EXAMPLE_ADDRESS = {
 
 
 class AddressResponse(Response):
-    data: AddressInDB | None = Field()
+    data: Address | AddressInDB | None = Field()
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/tests/api/routers/addresses/test_endpoints.py
+++ b/tests/api/routers/addresses/test_endpoints.py
@@ -127,15 +127,8 @@ class TestAddressEndpoints(unittest.TestCase):
                 self.services.search_by_id(self.address.id, str(self.company.id))
             )
 
-    def test_get_address_by_zip_existing(self):
-        resp = self.client.get(
-            f"/api/addresses/zip/{self.address.postal_code}"
-        )
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["data"]["id"], self.address.id)
-
     @patch("app.api.dependencies.get_address_by_zip_code.get_address_by_zip_code")
-    def test_get_address_by_zip_via_cep(self, mock_get):
+    def test_get_address_by_zip_always_via_cep(self, mock_get):
         mock_get.return_value = {
             "cep": "99999-000",
             "logradouro": "Street",
@@ -144,9 +137,12 @@ class TestAddressEndpoints(unittest.TestCase):
             "localidade": "City",
             "uf": "ST",
         }
-        resp = self.client.get("/api/addresses/zip/99999000")
+        resp = self.client.get(
+            f"/api/addresses/zip/{self.address.postal_code}"
+        )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json()["data"]["postal_code"], "99999-000")
+        self.assertEqual(resp.json()["data"]["postalCode"], "99999-000")
+        mock_get.assert_called_once()
 
     def test_create_address_returns_400_when_not_created(self):
         async def fake_create(address, company_id):

--- a/tests/crud/addresses/test_services.py
+++ b/tests/crud/addresses/test_services.py
@@ -78,14 +78,9 @@ class TestAddressServices(unittest.TestCase):
         with self.assertRaises(NotFoundError):
             asyncio.run(self.services.delete_by_id("invalid", "com1"))
 
-    def test_search_by_zip_code_existing(self):
-        doc = AddressModel(**self._build_address("12345").model_dump(), company_id="com1")
-        doc.save()
-        res = asyncio.run(self.services.search_by_zip_code("12345", "com1"))
-        self.assertEqual(res.id, doc.id)
-
     @patch("app.api.dependencies.get_address_by_zip_code.get_address_by_zip_code")
-    def test_search_by_zip_code_via_cep(self, mock_get):
+    def test_search_by_zip_code_always_via_cep(self, mock_get):
+        AddressModel(**self._build_address("12345").model_dump(), company_id="com1").save()
         mock_get.return_value = {
             "cep": "99999-000",
             "logradouro": "Street",
@@ -94,8 +89,9 @@ class TestAddressServices(unittest.TestCase):
             "localidade": "City",
             "uf": "ST",
         }
-        res = asyncio.run(self.services.search_by_zip_code("99999000", "com1"))
+        res = asyncio.run(self.services.search_by_zip_code("12345", "com1"))
         self.assertEqual(res.postal_code, "99999-000")
+        mock_get.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove database lookup when fetching address by ZIP
- allow address responses to return non-persisted addresses
- test that ZIP search always uses ViaCEP

## Testing
- `pytest tests/api/routers/addresses/test_endpoints.py tests/crud/addresses/test_services.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4bcc9eefc832ab797100d18352d10