### PR TITLE
Return 400 when reservation items are unavailable

### DIFF
--- a/app/api/routers/exception_handlers/generic_errors.py
+++ b/app/api/routers/exception_handlers/generic_errors.py
@@ -7,6 +7,7 @@ from app.core.exceptions import (
     InvalidPassword,
     NotFoundError,
     UnprocessableEntity,
+    BadRequestError,
 )
 from app.core.configs import get_logger
 
@@ -40,7 +41,7 @@ def not_found_error_404(request: Request, exc: NotFoundError):
     )
 
 
-def generic_error_400(request: Request, exc: InvalidPassword):
+def generic_error_400(request: Request, exc: InvalidPassword | BadRequestError):
     error = MessageResponse(message=exc.message)
 
     return JSONResponse(

--- a/app/application.py
+++ b/app/application.py
@@ -28,7 +28,12 @@ from app.api.routers.exception_handlers import (
 )
 from app.api.routers.exception_handlers.generic_errors import http_exception_handler
 from app.core.db.connection import lifespan
-from app.core.exceptions import UnprocessableEntity, NotFoundError, InvalidPassword
+from app.core.exceptions import (
+    UnprocessableEntity,
+    NotFoundError,
+    InvalidPassword,
+    BadRequestError,
+)
 from app.core.configs import get_environment
 
 _env = get_environment()
@@ -82,6 +87,7 @@ app.add_exception_handler(StarletteHTTPException, http_exception_handler)
 app.add_exception_handler(UnprocessableEntity, unprocessable_entity_error_422)
 app.add_exception_handler(NotFoundError, not_found_error_404)
 app.add_exception_handler(InvalidPassword, generic_error_400)
+app.add_exception_handler(BadRequestError, generic_error_400)
 app.add_exception_handler(Exception, generic_error_500)
 
 

--- a/app/core/exceptions/__init__.py
+++ b/app/core/exceptions/__init__.py
@@ -1,1 +1,6 @@
-from .users import InvalidPassword, UnprocessableEntity, NotFoundError
+from .users import (
+    InvalidPassword,
+    UnprocessableEntity,
+    NotFoundError,
+    BadRequestError,
+)

--- a/app/core/exceptions/users.py
+++ b/app/core/exceptions/users.py
@@ -24,3 +24,10 @@ class NotFoundError(Exception):
 
     def __init__(self, message="Not found") -> None:
         self.message = message
+
+
+class BadRequestError(Exception):
+    """Raised when a request cannot be processed"""
+
+    def __init__(self, message="Bad request") -> None:
+        self.message = message

--- a/app/crud/reservations/services.py
+++ b/app/crud/reservations/services.py
@@ -1,7 +1,7 @@
 from typing import List
 from decimal import Decimal
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import BadRequestError
 from app.core.utils.utc_datetime import UTCDateTime
 from app.crud.kegs.repositories import KegRepository
 from app.crud.kegs.schemas import KegStatus
@@ -35,15 +35,15 @@ class ReservationServices:
 
     async def create(self, reservation: Reservation, company_id: str) -> ReservationInDB:
         if not reservation.beer_dispenser_ids:
-            raise NotFoundError(message="At least one beer dispenser is required")
+            raise BadRequestError(message="At least one beer dispenser is required")
         if not reservation.keg_ids:
-            raise NotFoundError(message="At least one keg is required")
+            raise BadRequestError(message="At least one keg is required")
         if not reservation.extractor_ids:
-            raise NotFoundError(message="At least one extractor is required")
+            raise BadRequestError(message="At least one extractor is required")
         if not reservation.pressure_gauge_ids:
-            raise NotFoundError(message="At least one pressure gauge is required")
+            raise BadRequestError(message="At least one pressure gauge is required")
         if not reservation.cylinder_ids:
-            raise NotFoundError(message="At least one cylinder is required")
+            raise BadRequestError(message="At least one cylinder is required")
 
         total = Decimal("0")
         for keg_id in reservation.keg_ids:
@@ -51,7 +51,7 @@ class ReservationServices:
                 keg_id, company_id
             )
             if keg.status in [KegStatus.EMPTY, KegStatus.IN_USE]:
-                raise NotFoundError(message=f"Keg #{keg_id} not available")
+                raise BadRequestError(message=f"Keg #{keg_id} not available")
             price = keg.sale_price_per_l or Decimal("0")
             total += price * Decimal(keg.size_l)
 
@@ -60,11 +60,11 @@ class ReservationServices:
                 cylinder_id, company_id
             )
             if cylinder.status != CylinderStatus.AVAILABLE:
-                raise NotFoundError(
+                raise BadRequestError(
                     message=f"Cylinder #{cylinder_id} not available"
                 )
             if cylinder.weight_kg <= Decimal("0"):
-                raise NotFoundError(
+                raise BadRequestError(
                     message=f"Cylinder #{cylinder_id} empty"
                 )
 
@@ -75,7 +75,7 @@ class ReservationServices:
             pickup_date=reservation.pickup_date,
         )
         if conflict:
-            raise NotFoundError(
+            raise BadRequestError(
                 message="Beer dispenser already reserved for this period"
             )
 
@@ -86,7 +86,7 @@ class ReservationServices:
             pickup_date=reservation.pickup_date,
         )
         if conflict:
-            raise NotFoundError(
+            raise BadRequestError(
                 message="Cylinder already reserved for this period"
             )
 

--- a/tests/crud/reservations/test_services.py
+++ b/tests/crud/reservations/test_services.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import mongomock
 from mongoengine import connect, disconnect
 
-from app.core.exceptions import NotFoundError
+from app.core.exceptions import BadRequestError
 from app.crud.beer_dispensers.models import BeerDispenserModel
 from app.crud.beer_dispensers.schemas import DispenserStatus, Voltage
 from app.crud.cylinders.models import CylinderModel
@@ -166,7 +166,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=2),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation2, self.company_id))
 
     def test_create_reservation_cylinder_conflict(self):
@@ -218,7 +218,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=2),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation2, self.company_id))
 
     def test_create_reservation_with_unavailable_cylinder(self):
@@ -239,7 +239,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=2),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation, self.company_id))
 
     def test_create_reservation_with_empty_cylinder(self):
@@ -266,7 +266,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=2),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation, self.company_id))
 
     def test_create_reservation_with_unavailable_keg(self):
@@ -309,7 +309,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=4),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation2, self.company_id))
 
     def test_add_update_delete_payment(self):
@@ -409,7 +409,7 @@ class TestReservationServices(unittest.TestCase):
             pickup_date=datetime.now() + timedelta(days=2),
             payments=[],
         )
-        with self.assertRaises(NotFoundError):
+        with self.assertRaises(BadRequestError):
             asyncio.run(self.services.create(reservation2, self.company_id))
 
 


### PR DESCRIPTION
## Summary
- add `BadRequestError` and map it to HTTP 400
- use `BadRequestError` in reservation creation when items are missing or unavailable
- update tests to expect 400 for unavailable reservation items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a54c845e18832a9f2305cab9688f58