### PR TITLE
feat: add status filter to keg listing

### DIFF
--- a/app/api/routers/kegs/query_routers.py
+++ b/app/api/routers/kegs/query_routers.py
@@ -4,7 +4,7 @@ from app.api.composers.keg_composite import keg_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
 from .schemas import KegResponse, KegListResponse
-from app.crud.kegs import KegServices
+from app.crud.kegs import KegServices, KegStatus
 from app.crud.companies.schemas import CompanyInDB
 
 router = APIRouter(tags=["Kegs"])
@@ -30,10 +30,11 @@ async def get_keg_by_id(
     responses={200: {"model": KegListResponse}, 204: {"description": "No Content"}},
 )
 async def get_kegs(
-    company: CompanyInDB = Depends(require_user_company),
+    status: KegStatus | None = None,
     services: KegServices = Depends(keg_composer),
+    company: CompanyInDB = Depends(require_user_company),
 ):
-    kegs = await services.search_all(company_id=str(company.id))
+    kegs = await services.search_all(company_id=str(company.id), status=status)
     if kegs:
         return build_response(
             status_code=200, message="Kegs found with success", data=kegs

--- a/app/crud/kegs/repositories.py
+++ b/app/crud/kegs/repositories.py
@@ -64,12 +64,15 @@ class KegRepository(Repository):
             _logger.error(f"Error on select_by_id: {str(error)}")
             raise NotFoundError(message=f"Keg #{id} not found")
 
-    async def select_all(self, company_id: str) -> List[KegInDB]:
+    async def select_all(
+        self, company_id: str, status: str | None = None
+    ) -> List[KegInDB]:
         try:
+            query = KegModel.objects(company_id=company_id, is_active=True)
+            if status:
+                query = query.filter(status=status)
             kegs: List[KegInDB] = []
-            for model in KegModel.objects(company_id=company_id, is_active=True).order_by(
-                "number"
-            ):
+            for model in query.order_by("number"):
                 kegs.append(KegInDB.model_validate(model))
             return kegs
         except Exception as error:

--- a/app/crud/kegs/services.py
+++ b/app/crud/kegs/services.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from .repositories import KegRepository
-from .schemas import Keg, KegInDB, UpdateKeg
+from .schemas import Keg, KegInDB, UpdateKeg, KegStatus
 
 
 class KegServices:
@@ -18,8 +18,13 @@ class KegServices:
     async def search_by_id(self, id: str, company_id: str) -> KegInDB:
         return await self.__repository.select_by_id(id=id, company_id=company_id)
 
-    async def search_all(self, company_id: str) -> List[KegInDB]:
-        return await self.__repository.select_all(company_id=company_id)
+    async def search_all(
+        self, company_id: str, status: KegStatus | None = None
+    ) -> List[KegInDB]:
+        status_value = status.value if status else None
+        return await self.__repository.select_all(
+            company_id=company_id, status=status_value
+        )
 
     async def delete_by_id(self, id: str, company_id: str) -> KegInDB:
         return await self.__repository.delete_by_id(id=id, company_id=company_id)

--- a/tests/api/routers/kegs/test_endpoints.py
+++ b/tests/api/routers/kegs/test_endpoints.py
@@ -121,6 +121,27 @@ class TestKegEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertGreaterEqual(len(resp.json()["data"]), 1)
 
+    def test_list_kegs_filtered_by_status(self):
+        other_keg = Keg(
+            number="2",
+            size_l=50,
+            beer_type_id=str(self.beer_type.id),
+            cost_price_per_l=5.0,
+            sale_price_per_l=8.0,
+            lot="L2",
+            expiration_date=None,
+            current_volume_l=25.0,
+            status=KegStatus.IN_USE,
+            notes="",
+        )
+        asyncio.run(self.services.create(other_keg, str(self.company.id)))
+        resp = self.client.get(
+            "/api/kegs", params={"status": KegStatus.AVAILABLE.value}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["data"]), 1)
+        self.assertEqual(resp.json()["data"][0]["id"], self.keg.id)
+
     def test_update_keg_endpoint(self):
         resp = self.client.put(
             f"/api/kegs/{self.keg.id}",

--- a/tests/crud/kegs/test_repository.py
+++ b/tests/crud/kegs/test_repository.py
@@ -69,6 +69,19 @@ class TestKegRepository(unittest.TestCase):
         res = asyncio.run(repository.select_all("com1"))
         self.assertEqual(len(res), 2)
 
+    def test_select_all_filtered_by_status(self):
+        keg1 = self._build_keg("1")
+        KegModel(**keg1.model_dump(), company_id="com1").save()
+        keg2 = self._build_keg("2")
+        keg2.status = KegStatus.IN_USE
+        KegModel(**keg2.model_dump(), company_id="com1").save()
+        repository = KegRepository()
+        res = asyncio.run(
+            repository.select_all("com1", status=KegStatus.AVAILABLE.value)
+        )
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].status, KegStatus.AVAILABLE)
+
     def test_update_keg(self):
         doc = KegModel(**self._build_keg().model_dump(), company_id="com1")
         doc.save()

--- a/tests/crud/kegs/test_services.py
+++ b/tests/crud/kegs/test_services.py
@@ -60,6 +60,18 @@ class TestKegServices(unittest.TestCase):
         res = asyncio.run(self.services.search_all("com1"))
         self.assertEqual(len(res), 1)
 
+    def test_search_all_filtered_by_status(self):
+        keg1 = self._build_keg("1")
+        KegModel(**keg1.model_dump(), company_id="com1").save()
+        keg2 = self._build_keg("2")
+        keg2.status = KegStatus.IN_USE
+        KegModel(**keg2.model_dump(), company_id="com1").save()
+        res = asyncio.run(
+            self.services.search_all("com1", status=KegStatus.AVAILABLE)
+        )
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].status, KegStatus.AVAILABLE)
+
     def test_update_keg(self):
         doc = KegModel(**self._build_keg().model_dump(), company_id="com1")
         doc.save()


### PR DESCRIPTION
## Summary
- add optional status filter to keg listing endpoint
- support status filtering in keg services and repository
- cover new behavior with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a54f3de6a4832aa84c3adf80c24589