### PR TITLE
Display current reservation in dispenser list

### DIFF
--- a/app/crud/reservations/repositories.py
+++ b/app/crud/reservations/repositories.py
@@ -202,11 +202,14 @@ class ReservationRepository(Repository):
         self, company_id: str, dispenser_id: str
     ) -> ReservationInDB | None:
         try:
+            now = UTCDateTime.now()
             model = ReservationModel.objects(
                 beer_dispenser_ids=dispenser_id,
                 company_id=company_id,
                 is_active=True,
                 status__ne=ReservationStatus.COMPLETED.value,
+                delivery_date__lte=now,
+                pickup_date__gte=now,
             ).first()
 
             return ReservationInDB.model_validate(model) if model else None

--- a/tests/crud/reservations/test_repository.py
+++ b/tests/crud/reservations/test_repository.py
@@ -120,6 +120,84 @@ class TestReservationRepository(unittest.TestCase):
         )
         self.assertEqual(len(updated.payments), 0)
 
+    def test_find_active_by_beer_dispenser_id_within_period(self):
+        reservation = Reservation(
+            customer_id="cus1",
+            address_id="add2",
+            beer_dispenser_ids=[str(self.dispenser.id)],
+            keg_ids=[str(self.keg.id)],
+            extractor_ids=[str(self.extractor.id)],
+            pressure_gauge_ids=[str(self.pg.id)],
+            cylinder_ids=[str(self.cylinder.id)],
+            freight_value=Decimal("0"),
+            additional_value=Decimal("0"),
+            discount=Decimal("0"),
+            delivery_date=datetime.now() - timedelta(hours=1),
+            pickup_date=datetime.now() + timedelta(hours=1),
+            payments=[],
+            total_value=Decimal("400.00"),
+            status=ReservationStatus.RESERVED,
+        )
+        res = asyncio.run(self.repository.create(reservation, self.company_id))
+        found = asyncio.run(
+            self.repository.find_active_by_beer_dispenser_id(
+                self.company_id, str(self.dispenser.id)
+            )
+        )
+        self.assertEqual(found.id, res.id)
+
+    def test_find_active_by_beer_dispenser_id_outside_period(self):
+        reservation = Reservation(
+            customer_id="cus1",
+            address_id="add2",
+            beer_dispenser_ids=[str(self.dispenser.id)],
+            keg_ids=[str(self.keg.id)],
+            extractor_ids=[str(self.extractor.id)],
+            pressure_gauge_ids=[str(self.pg.id)],
+            cylinder_ids=[str(self.cylinder.id)],
+            freight_value=Decimal("0"),
+            additional_value=Decimal("0"),
+            discount=Decimal("0"),
+            delivery_date=datetime.now() + timedelta(days=1),
+            pickup_date=datetime.now() + timedelta(days=2),
+            payments=[],
+            total_value=Decimal("400.00"),
+            status=ReservationStatus.RESERVED,
+        )
+        asyncio.run(self.repository.create(reservation, self.company_id))
+        found = asyncio.run(
+            self.repository.find_active_by_beer_dispenser_id(
+                self.company_id, str(self.dispenser.id)
+            )
+        )
+        self.assertIsNone(found)
+
+    def test_find_active_by_beer_dispenser_id_completed(self):
+        reservation = Reservation(
+            customer_id="cus1",
+            address_id="add2",
+            beer_dispenser_ids=[str(self.dispenser.id)],
+            keg_ids=[str(self.keg.id)],
+            extractor_ids=[str(self.extractor.id)],
+            pressure_gauge_ids=[str(self.pg.id)],
+            cylinder_ids=[str(self.cylinder.id)],
+            freight_value=Decimal("0"),
+            additional_value=Decimal("0"),
+            discount=Decimal("0"),
+            delivery_date=datetime.now() - timedelta(hours=1),
+            pickup_date=datetime.now() + timedelta(hours=1),
+            payments=[],
+            total_value=Decimal("400.00"),
+            status=ReservationStatus.COMPLETED,
+        )
+        asyncio.run(self.repository.create(reservation, self.company_id))
+        found = asyncio.run(
+            self.repository.find_active_by_beer_dispenser_id(
+                self.company_id, str(self.dispenser.id)
+            )
+        )
+        self.assertIsNone(found)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show reservation ID for a dispenser only when it has an active reservation
- cover reservation repository with tests for active, future and completed scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d35724a4832a84840d8ca38ed4c9