### PR TITLE
Return 200 with empty arrays for empty list endpoints

### DIFF
--- a/app/api/dependencies/response.py
+++ b/app/api/dependencies/response.py
@@ -14,10 +14,8 @@ def build_response(
     if isinstance(data, int):
         raw_response = Response(message=message, data=None)
         raw_response.data = data
-
-    elif data:
+    elif data is not None:
         raw_response = Response(message=message, data=data)
-
     else:
         raw_response = MessageResponse(message=message)
 
@@ -30,13 +28,12 @@ def build_response(
 def build_list_response(
     status_code: status, message: str, pagination: dict, data: BaseModel | List[BaseModel] = None
 ) -> JSONResponse:
-    if data:
+    if data is not None:
         raw_response = ListResponseSchema(
             message=message,
             pagination=pagination,
             data=data
         )
-
     else:
         raw_response = MessageResponse(message=message)
 

--- a/app/api/routers/addresses/query_routers.py
+++ b/app/api/routers/addresses/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.address_composite import address_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,18 +29,18 @@ async def get_address_by_id(
 
 @router.get(
     "/addresses",
-    responses={200: {"model": AddressListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": AddressListResponse}},
 )
 async def get_addresses(
     address_services: AddressServices = Depends(address_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     addresses = await address_services.search_all(company_id=str(company.id))
-    if addresses:
-        return build_response(
-            status_code=200, message="Addresses found with success", data=addresses
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Addresses found with success",
+        data=addresses or [],
+    )
 
 
 @router.get(

--- a/app/api/routers/beer_dispensers/query_routers.py
+++ b/app/api/routers/beer_dispensers/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.beer_dispenser_composite import beer_dispenser_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,17 +29,15 @@ async def get_beer_dispenser_by_id(
 
 @router.get(
     "/beer-dispensers",
-    responses={200: {"model": BeerDispenserListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": BeerDispenserListResponse}},
 )
 async def get_beer_dispensers(
     services: BeerDispenserServices = Depends(beer_dispenser_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     dispensers = await services.search_all(company_id=str(company.id))
-    if dispensers:
-        return build_response(
-            status_code=200,
-            message="Beer dispensers found with success",
-            data=dispensers,
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Beer dispensers found with success",
+        data=dispensers or [],
+    )

--- a/app/api/routers/beer_types/query_routers.py
+++ b/app/api/routers/beer_types/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.beer_type_composite import beer_type_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,15 +29,15 @@ async def get_beer_type_by_id(
 
 @router.get(
     "/beer-types",
-    responses={200: {"model": BeerTypeListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": BeerTypeListResponse}},
 )
 async def get_beer_types(
     services: BeerTypeServices = Depends(beer_type_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     beer_types = await services.search_all(company_id=str(company.id))
-    if beer_types:
-        return build_response(
-            status_code=200, message="Beer types found with success", data=beer_types
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Beer types found with success",
+        data=beer_types or [],
+    )

--- a/app/api/routers/companies/query_routers.py
+++ b/app/api/routers/companies/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.company_composite import company_composer
 from app.api.dependencies import build_response, require_company_member, require_user_company
@@ -44,15 +44,13 @@ async def get_company_subscription(
 
 @router.get(
     "/companies",
-    responses={200: {"model": CompanyListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": CompanyListResponse}},
 )
 async def get_companies(
     company_services: CompanyServices = Depends(company_composer),
     _: CompanyInDB = Depends(require_user_company),
 ):
     companies = await company_services.search_all()
-    if companies:
-        return build_response(
-            status_code=200, message="Companies found with success", data=companies
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200, message="Companies found with success", data=companies or []
+    )

--- a/app/api/routers/customers/query_routers.py
+++ b/app/api/routers/customers/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.customer_composite import customer_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,15 +29,15 @@ async def get_customer_by_id(
 
 @router.get(
     "/customers",
-    responses={200: {"model": CustomerListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": CustomerListResponse}},
 )
 async def get_customers(
     customer_services: CustomerServices = Depends(customer_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     customers = await customer_services.search_all(company_id=str(company.id))
-    if customers:
-        return build_response(
-            status_code=200, message="Customers found with success", data=customers
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Customers found with success",
+        data=customers or [],
+    )

--- a/app/api/routers/cylinders/query_routers.py
+++ b/app/api/routers/cylinders/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 from app.core.exceptions import NotFoundError
 
 from app.api.composers.cylinder_composite import cylinder_composer
@@ -32,7 +32,7 @@ async def get_cylinder_by_id(
 
 @router.get(
     "/cylinders",
-    responses={200: {"model": CylinderListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": CylinderListResponse}},
 )
 async def get_cylinders(
     services: CylinderServices = Depends(cylinder_composer),
@@ -41,11 +41,9 @@ async def get_cylinders(
     try:
         cylinders = await services.search_all(company_id=str(company.id))
     except NotFoundError:
-        return Response(status_code=204)
-    if cylinders:
-        return build_response(
-            status_code=200,
-            message="Cylinders found with success",
-            data=cylinders,
-        )
-    return Response(status_code=204)
+        cylinders = []
+    return build_response(
+        status_code=200,
+        message="Cylinders found with success",
+        data=cylinders,
+    )

--- a/app/api/routers/dashboard/query_routers.py
+++ b/app/api/routers/dashboard/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.dashboard_composite import dashboard_composer
 from app.api.dependencies import build_response, require_user_company
@@ -33,20 +33,18 @@ async def get_monthly_revenue(
 
 @router.get(
     "/dashboard/upcoming-reservations",
-    responses={200: {"model": ReservationListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": ReservationListResponse}},
 )
 async def get_upcoming_reservations(
     services: DashboardServices = Depends(dashboard_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     reservations = await services.upcoming_reservations(company_id=str(company.id))
-    if reservations:
-        return build_response(
-            status_code=200,
-            message="Reservations found with success",
-            data=reservations,
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Reservations found with success",
+        data=reservations or [],
+    )
 
 
 @router.get(

--- a/app/api/routers/extractors/query_routers.py
+++ b/app/api/routers/extractors/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.extractor_composite import extractor_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,15 +29,15 @@ async def get_extractor_by_id(
 
 @router.get(
     "/extractors",
-    responses={200: {"model": ExtractorListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": ExtractorListResponse}},
 )
 async def get_extractors(
     extractor_services: ExtractorServices = Depends(extractor_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     extractors = await extractor_services.search_all(company_id=str(company.id))
-    if extractors:
-        return build_response(
-            status_code=200, message="Extractors found with success", data=extractors
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Extractors found with success",
+        data=extractors or [],
+    )

--- a/app/api/routers/kegs/query_routers.py
+++ b/app/api/routers/kegs/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.keg_composite import keg_composer
 from app.api.dependencies import build_response, require_user_company
@@ -27,7 +27,7 @@ async def get_keg_by_id(
 
 @router.get(
     "/kegs",
-    responses={200: {"model": KegListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": KegListResponse}},
 )
 async def get_kegs(
     status: KegStatus | None = None,
@@ -35,8 +35,6 @@ async def get_kegs(
     company: CompanyInDB = Depends(require_user_company),
 ):
     kegs = await services.search_all(company_id=str(company.id), status=status)
-    if kegs:
-        return build_response(
-            status_code=200, message="Kegs found with success", data=kegs
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200, message="Kegs found with success", data=kegs or []
+    )

--- a/app/api/routers/payments/query_routers.py
+++ b/app/api/routers/payments/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.payment_composite import payment_composer
 from app.api.dependencies import build_response, require_user_company
@@ -12,7 +12,7 @@ router = APIRouter(tags=["Payments"])
 
 @router.get(
     "/payments",
-    responses={200: {"model": PaymentListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": PaymentListResponse}},
 )
 async def get_payments(
     status: PaymentStatus | None = None,
@@ -20,10 +20,8 @@ async def get_payments(
     company: CompanyInDB = Depends(require_user_company),
 ):
     payments = await services.search_all(company_id=str(company.id), status=status)
-    if payments:
-        return build_response(
-            status_code=200,
-            message="Payments found with success",
-            data=payments,
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Payments found with success",
+        data=payments or [],
+    )

--- a/app/api/routers/pressure_gauges/query_routers.py
+++ b/app/api/routers/pressure_gauges/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.pressure_gauge_composite import pressure_gauge_composer
 from app.api.dependencies import build_response, require_user_company
@@ -29,17 +29,15 @@ async def get_pressure_gauge_by_id(
 
 @router.get(
     "/pressure-gauges",
-    responses={200: {"model": PressureGaugeListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": PressureGaugeListResponse}},
 )
 async def get_pressure_gauges(
     services: PressureGaugeServices = Depends(pressure_gauge_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
     gauges = await services.search_all(company_id=str(company.id))
-    if gauges:
-        return build_response(
-            status_code=200,
-            message="Pressure gauges found with success",
-            data=gauges,
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Pressure gauges found with success",
+        data=gauges or [],
+    )

--- a/app/api/routers/reservations/query_routers.py
+++ b/app/api/routers/reservations/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends
 
 from app.api.composers.reservation_composite import reservation_composer
 from app.api.dependencies import build_response, require_user_company
@@ -30,7 +30,7 @@ async def get_reservation_by_id(
 
 @router.get(
     "/reservations",
-    responses={200: {"model": ReservationListResponse}, 204: {"description": "No Content"}},
+    responses={200: {"model": ReservationListResponse}},
 )
 async def get_reservations(
     start_date: UTCDateTimeType | None = None,
@@ -45,10 +45,8 @@ async def get_reservations(
         end_date=end_date,
         status=status,
     )
-    if reservations:
-        return build_response(
-            status_code=200,
-            message="Reservations found with success",
-            data=reservations,
-        )
-    return Response(status_code=204)
+    return build_response(
+        status_code=200,
+        message="Reservations found with success",
+        data=reservations or [],
+    )

--- a/app/api/routers/users/query_routers.py
+++ b/app/api/routers/users/query_routers.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Security, Response
+from fastapi import APIRouter, Depends, Security
 
 from app.api.composers.user_composite import user_composer
 from app.api.composers.company_composite import company_composer
@@ -94,7 +94,6 @@ async def get_user_by_email(
     "/users",
     responses={
         200: {"model": GetUsersResponse},
-        204: {"description": "No Content"},
     },
 )
 async def get_users(
@@ -103,10 +102,6 @@ async def get_users(
 ):
     users = await user_services.search_all()
 
-    if users:
-        return build_response(
-            status_code=200, message="Users found with success", data=users
-        )
-
-    else:
-        return Response(status_code=204)
+    return build_response(
+        status_code=200, message="Users found with success", data=users or []
+    )

--- a/tests/api/routers/cylinders/test_endpoints.py
+++ b/tests/api/routers/cylinders/test_endpoints.py
@@ -155,13 +155,14 @@ class TestCylinderEndpoints(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 400)
 
-    def test_list_cylinders_returns_204_when_not_found(self):
+    def test_list_cylinders_returns_empty_list_when_not_found(self):
         async def fake_search_all(company_id):
             raise NotFoundError("Cylinders not found")
 
         self.services.search_all = fake_search_all
         resp = self.client.get("/api/cylinders")
-        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["data"], [])
 
     def test_create_cylinder_appends_suffix_when_duplicate(self):
         resp = self.client.post(


### PR DESCRIPTION
## Summary
- send an empty array with 200 status on all list endpoints instead of 204
- allow response builder to serialize empty lists
- update cylinder list test for new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78cd10b94832aa4b7b26d23e97a34