### PR TITLE
Include upcoming reservations in dispenser listing

### DIFF
--- a/app/crud/reservations/repositories.py
+++ b/app/crud/reservations/repositories.py
@@ -227,14 +227,17 @@ class ReservationRepository(Repository):
     ) -> ReservationInDB | None:
         try:
             now = UTCDateTime.now()
-            model = ReservationModel.objects(
-                beer_dispenser_ids=dispenser_id,
-                company_id=company_id,
-                is_active=True,
-                status__ne=ReservationStatus.COMPLETED.value,
-                delivery_date__lte=now,
-                pickup_date__gte=now,
-            ).first()
+            model = (
+                ReservationModel.objects(
+                    beer_dispenser_ids=dispenser_id,
+                    company_id=company_id,
+                    is_active=True,
+                    status__ne=ReservationStatus.COMPLETED.value,
+                    pickup_date__gte=now,
+                )
+                .order_by("delivery_date")
+                .first()
+            )
 
             return ReservationInDB.model_validate(model) if model else None
 

--- a/tests/crud/reservations/test_repository.py
+++ b/tests/crud/reservations/test_repository.py
@@ -143,7 +143,7 @@ class TestReservationRepository(unittest.TestCase):
         )
         self.assertEqual(found.id, res.id)
 
-    def test_find_active_by_beer_dispenser_id_outside_period(self):
+    def test_find_active_by_beer_dispenser_id_future_period(self):
         reservation = ReservationCreate(
             customer_id="cus1",
             address_id="add2",
@@ -161,13 +161,13 @@ class TestReservationRepository(unittest.TestCase):
             total_cost=Decimal("250.00"),
             status=ReservationStatus.RESERVED,
         )
-        asyncio.run(self.repository.create(reservation, self.company_id))
+        res = asyncio.run(self.repository.create(reservation, self.company_id))
         found = asyncio.run(
             self.repository.find_active_by_beer_dispenser_id(
                 self.company_id, str(self.dispenser.id)
             )
         )
-        self.assertIsNone(found)
+        self.assertEqual(found.id, res.id)
 
     def test_find_active_by_beer_dispenser_id_completed(self):
         reservation = ReservationCreate(


### PR DESCRIPTION
## Summary
- return reservation ID for dispensers with upcoming bookings
- cover future reservations in service and repository tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a95d950c64832ab270b96722656d6e