### PR TITLE
Allow duplicate serial numbers for bar equipment

### DIFF
--- a/app/crud/beer_dispensers/services.py
+++ b/app/crud/beer_dispensers/services.py
@@ -2,7 +2,6 @@ from typing import List
 
 from .repositories import BeerDispenserRepository
 from .schemas import BeerDispenser, BeerDispenserInDB, UpdateBeerDispenser
-from .models import BeerDispenserModel
 from app.crud.reservations.repositories import ReservationRepository
 
 
@@ -16,13 +15,6 @@ class BeerDispenserServices:
         self.__reservation_repository = reservation_repository or ReservationRepository()
 
     async def create(self, dispenser: BeerDispenser, company_id: str) -> BeerDispenserInDB:
-        if dispenser.serial_number is not None:
-            existing = BeerDispenserModel.objects(
-                serial_number__startswith=dispenser.serial_number,
-                company_id=company_id,
-            ).count()
-            if existing > 0:
-                dispenser.serial_number = f"{dispenser.serial_number}{existing}"
         return await self.__repository.create(dispenser=dispenser, company_id=company_id)
 
     async def update(

--- a/app/crud/cylinders/repositories.py
+++ b/app/crud/cylinders/repositories.py
@@ -20,16 +20,6 @@ class CylinderRepository(Repository):
 
     async def create(self, cylinder: Cylinder, company_id: str) -> CylinderInDB:
         try:
-            exists = CylinderModel.objects(
-                number=cylinder.number,
-                company_id=company_id,
-                is_active=True,
-            ).first()
-            if exists:
-                raise NotFoundError(
-                    message=f"Cylinder #{cylinder.number} already exists"
-                )
-
             json = jsonable_encoder(cylinder.model_dump())
             model = CylinderModel(
                 is_active=True,
@@ -40,8 +30,6 @@ class CylinderRepository(Repository):
             )
             model.save()
             return CylinderInDB.model_validate(model)
-        except NotFoundError:
-            raise
         except Exception as error:
             _logger.error(f"Error on create_cylinder: {str(error)}")
             raise NotFoundError(message="Error on create new cylinder")

--- a/app/crud/cylinders/services.py
+++ b/app/crud/cylinders/services.py
@@ -2,7 +2,6 @@ from typing import List
 
 from .repositories import CylinderRepository
 from .schemas import Cylinder, CylinderInDB, UpdateCylinder
-from .models import CylinderModel
 
 
 class CylinderServices:
@@ -10,11 +9,6 @@ class CylinderServices:
         self.__repository = repository
 
     async def create(self, cylinder: Cylinder, company_id: str) -> CylinderInDB:
-        existing = CylinderModel.objects(
-            number__startswith=cylinder.number, company_id=company_id
-        ).count()
-        if existing > 0:
-            cylinder.number = f"{cylinder.number}{existing}"
         return await self.__repository.create(cylinder=cylinder, company_id=company_id)
 
     async def update(

--- a/app/crud/kegs/models.py
+++ b/app/crud/kegs/models.py
@@ -11,14 +11,7 @@ from .schemas import KegStatus
 
 
 class KegModel(BaseDocument):
-    """Persistence model for beer kegs.
-
-    The original model enforced a globally unique ``number`` field which caused
-    several tests to fail when multiple kegs with the same number were created
-    across different test cases.  To keep numbers unique only within a company
-    and to automatically avoid collisions we manage the value during ``save``
-    similarly to other entities in the project.
-    """
+    """Persistence model for beer kegs."""
 
     number = StringField(required=True)
     size_l = IntField(required=True)
@@ -39,16 +32,6 @@ class KegModel(BaseDocument):
             "beer_type_id",
             "expiration_date",
             "company_id",
-            {"fields": ["number", "company_id"], "unique": True},
+            {"fields": ["number", "company_id"]},
         ],
     }
-
-    def save(self, *args, **kwargs):
-        base_number = self.number
-        counter = 1
-        while KegModel.objects(
-            number=self.number, company_id=self.company_id, id__ne=self.id
-        ):
-            self.number = f"{base_number}{counter}"
-            counter += 1
-        super().save(*args, **kwargs)

--- a/app/crud/kegs/services.py
+++ b/app/crud/kegs/services.py
@@ -2,7 +2,6 @@ from typing import List
 
 from .repositories import KegRepository
 from .schemas import Keg, KegInDB, UpdateKeg, KegStatus
-from .models import KegModel
 
 
 class KegServices:
@@ -10,11 +9,6 @@ class KegServices:
         self.__repository = keg_repository
 
     async def create(self, keg: Keg, company_id: str) -> KegInDB:
-        existing = KegModel.objects(
-            number__startswith=keg.number, company_id=company_id
-        ).count()
-        if existing > 0:
-            keg.number = f"{keg.number}{existing}"
         return await self.__repository.create(keg=keg, company_id=company_id)
 
     async def update(self, id: str, company_id: str, keg: UpdateKeg) -> KegInDB:

--- a/tests/api/routers/cylinders/test_endpoints.py
+++ b/tests/api/routers/cylinders/test_endpoints.py
@@ -164,15 +164,13 @@ class TestCylinderEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["data"], [])
 
-    def test_create_cylinder_appends_suffix_when_duplicate(self):
+    def test_create_cylinder_allows_duplicate_number(self):
         resp = self.client.post(
             "/api/cylinders",
             json=self._payload(number=self.cylinder.number),
         )
         self.assertEqual(resp.status_code, 201)
-        self.assertEqual(
-            resp.json()["data"]["number"], f"{self.cylinder.number}1"
-        )
+        self.assertEqual(resp.json()["data"]["number"], self.cylinder.number)
 
 
 if __name__ == "__main__":

--- a/tests/crud/beer_dispensers/test_services.py
+++ b/tests/crud/beer_dispensers/test_services.py
@@ -46,15 +46,16 @@ class TestBeerDispenserServices(unittest.TestCase):
         result = asyncio.run(self.services.create(self._build_dispenser(), "com1"))
         self.assertEqual(result.brand, "Acme")
 
-    def test_create_dispenser_with_automatic_suffix(self):
+    def test_create_dispenser_allows_duplicate_serial_number(self):
         first = asyncio.run(
             self.services.create(self._build_dispenser(serial_number="SN"), "com1")
         )
-        self.assertEqual(first.serial_number, "SN")
         second = asyncio.run(
             self.services.create(self._build_dispenser(serial_number="SN"), "com1")
         )
-        self.assertEqual(second.serial_number, "SN1")
+        self.assertEqual(first.serial_number, "SN")
+        self.assertEqual(second.serial_number, "SN")
+        self.assertNotEqual(first.id, second.id)
 
     def test_search_by_id(self):
         doc = BeerDispenserModel(**self._build_dispenser().model_dump(), company_id="com1")

--- a/tests/crud/cylinders/test_repository.py
+++ b/tests/crud/cylinders/test_repository.py
@@ -89,23 +89,15 @@ class TestCylinderRepository(unittest.TestCase):
         with self.assertRaises(NotFoundError):
             asyncio.run(repository.delete_by_id("invalid", "com1"))
 
-    def test_create_cylinder_duplicate_number_active(self):
-        repository = CylinderRepository()
-        cylinder = self._build_cylinder()
-        asyncio.run(repository.create(cylinder, company_id="com1"))
-        with self.assertRaises(NotFoundError):
-            asyncio.run(repository.create(cylinder, company_id="com1"))
-
-    def test_create_cylinder_after_soft_delete(self):
+    def test_create_cylinder_allows_duplicate_number(self):
         repository = CylinderRepository()
         cylinder = self._build_cylinder()
         first = asyncio.run(repository.create(cylinder, company_id="com1"))
-        asyncio.run(repository.delete_by_id(first.id, first.company_id))
         second = asyncio.run(repository.create(cylinder, company_id="com1"))
+        self.assertEqual(first.number, cylinder.number)
         self.assertEqual(second.number, cylinder.number)
-        self.assertNotEqual(first.id, second.id)
         self.assertEqual(
-            CylinderModel.objects(number=cylinder.number, is_active=True).count(), 1
+            CylinderModel.objects(number=cylinder.number, is_active=True).count(), 2
         )
 
 

--- a/tests/crud/cylinders/test_services.py
+++ b/tests/crud/cylinders/test_services.py
@@ -40,15 +40,16 @@ class TestCylinderServices(unittest.TestCase):
         )
         self.assertEqual(result.brand, "Acme")
 
-    def test_create_cylinder_with_automatic_suffix(self):
+    def test_create_cylinder_allows_duplicate_number(self):
         first = asyncio.run(
             self.services.create(self._build_cylinder(number="CY"), "com1")
         )
-        self.assertEqual(first.number, "CY")
         second = asyncio.run(
             self.services.create(self._build_cylinder(number="CY"), "com1")
         )
-        self.assertEqual(second.number, "CY1")
+        self.assertEqual(first.number, "CY")
+        self.assertEqual(second.number, "CY")
+        self.assertNotEqual(first.id, second.id)
 
     def test_search_by_id(self):
         doc = CylinderModel(

--- a/tests/crud/kegs/test_services.py
+++ b/tests/crud/kegs/test_services.py
@@ -48,11 +48,12 @@ class TestKegServices(unittest.TestCase):
         result = asyncio.run(self.services.create(self._build_keg(), "com1"))
         self.assertEqual(result.number, "1")
 
-    def test_create_keg_with_automatic_suffix(self):
+    def test_create_keg_allows_duplicate_number(self):
         first = asyncio.run(self.services.create(self._build_keg("10"), "com1"))
-        self.assertEqual(first.number, "10")
         second = asyncio.run(self.services.create(self._build_keg("10"), "com1"))
-        self.assertEqual(second.number, "101")
+        self.assertEqual(first.number, "10")
+        self.assertEqual(second.number, "10")
+        self.assertNotEqual(first.id, second.id)
 
     def test_search_by_id(self):
         doc = KegModel(**self._build_keg().model_dump(), company_id="com1")


### PR DESCRIPTION
## Summary
- permit registering kegs, cylinders and beer dispensers with duplicate numbers/serials
- drop keg number auto-increment and unique index
- update tests for new duplicate handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adb66bc1f8832ab4f4a8c2ce4a17c1