### PR TITLE
Ensure customer document uniqueness per company

### DIFF
--- a/app/crud/customers/models.py
+++ b/app/crud/customers/models.py
@@ -7,7 +7,7 @@ from app.core.utils.validate_document import validate_cpf, validate_cnpj
 
 class CustomerModel(BaseDocument):
     name = StringField(required=True)
-    document = StringField(required=True, unique=True)
+    document = StringField(required=True)
     email = StringField()
     mobile = StringField()
     birth_date = StringField()
@@ -17,6 +17,10 @@ class CustomerModel(BaseDocument):
 
     meta = {
         "collection": "customers",
+        "indexes": [
+            "company_id",
+            {"fields": ["document", "company_id"], "unique": True},
+        ],
     }
 
     def clean(self):

--- a/app/crud/customers/repositories.py
+++ b/app/crud/customers/repositories.py
@@ -32,7 +32,9 @@ class CustomerRepository(Repository):
             customer_model.save()
             return CustomerInDB.model_validate(customer_model)
         except NotUniqueError:
-            raise UnprocessableEntity(message="Customer document should be unique")
+            raise UnprocessableEntity(
+                message="Customer document should be unique for the company"
+            )
         except Exception as error:
             _logger.error(f"Error on create_customer: {str(error)}")
             raise UnprocessableEntity(message="Error on create new customer")

--- a/tests/crud/customers/test_repository.py
+++ b/tests/crud/customers/test_repository.py
@@ -49,6 +49,17 @@ class TestCustomerRepository(unittest.TestCase):
                 repository.create(self._build_customer("10000000019"), company_id="com1")
             )
 
+    def test_create_customer_same_document_different_company(self):
+        repository = CustomerRepository()
+        asyncio.run(
+            repository.create(self._build_customer("10000000019"), company_id="com1")
+        )
+        result = asyncio.run(
+            repository.create(self._build_customer("10000000019"), company_id="com2")
+        )
+        self.assertEqual(result.document, "10000000019")
+        self.assertEqual(CustomerModel.objects.count(), 2)
+
     def test_create_customer_more_than_five_addresses(self):
         repository = CustomerRepository()
         customer = self._build_customer()

--- a/tests/crud/customers/test_services.py
+++ b/tests/crud/customers/test_services.py
@@ -51,6 +51,15 @@ class TestCustomerServices(unittest.TestCase):
                 self.services.create(self._build_customer("10000000019"), company_id="com1")
             )
 
+    def test_create_customer_same_document_different_company(self):
+        asyncio.run(
+            self.services.create(self._build_customer("10000000019"), company_id="com1")
+        )
+        result = asyncio.run(
+            self.services.create(self._build_customer("10000000019"), company_id="com2")
+        )
+        self.assertEqual(result.document, "10000000019")
+
     def test_search_by_id(self):
         doc = CustomerModel(**self._build_customer().model_dump(), company_id="com1")
         doc.save()


### PR DESCRIPTION
## Summary
- enforce unique customer documents per company with compound index
- improve repository validation message and add tests

## Testing
- `pip install -r requirements/dev.txt`
- `pytest tests/crud/customers/test_repository.py::TestCustomerRepository::test_create_customer_unique_document -q`
- `pytest tests/crud/customers/test_repository.py::TestCustomerRepository::test_create_customer_same_document_different_company -q`
- `pytest tests/crud/customers/test_services.py::TestCustomerServices::test_create_customer_unique_document -q`
- `pytest tests/crud/customers/test_services.py::TestCustomerServices::test_create_customer_same_document_different_company -q`


------
https://chatgpt.com/codex/tasks/task_e_68be4e5fbf0c832abfb87cefbbdb87e9