### PR TITLE
Ensure list endpoints return empty arrays on no data

### DIFF
--- a/app/api/routers/addresses/query_routers.py
+++ b/app/api/routers/addresses/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.address_composite import address_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import AddressResponse, AddressListResponse
 from app.crud.addresses import AddressServices
 from app.crud.companies.schemas import CompanyInDB
@@ -35,11 +36,14 @@ async def get_addresses(
     address_services: AddressServices = Depends(address_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    addresses = await address_services.search_all(company_id=str(company.id))
+    try:
+        addresses = await address_services.search_all(company_id=str(company.id))
+    except NotFoundError:
+        addresses = []
     return build_response(
         status_code=200,
         message="Addresses found with success",
-        data=addresses or [],
+        data=addresses,
     )
 
 

--- a/app/api/routers/beer_dispensers/query_routers.py
+++ b/app/api/routers/beer_dispensers/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.beer_dispenser_composite import beer_dispenser_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import BeerDispenserResponse, BeerDispenserListResponse
 from app.crud.beer_dispensers import BeerDispenserServices
 from app.crud.companies.schemas import CompanyInDB
@@ -35,9 +36,12 @@ async def get_beer_dispensers(
     services: BeerDispenserServices = Depends(beer_dispenser_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    dispensers = await services.search_all(company_id=str(company.id))
+    try:
+        dispensers = await services.search_all(company_id=str(company.id))
+    except NotFoundError:
+        dispensers = []
     return build_response(
         status_code=200,
         message="Beer dispensers found with success",
-        data=dispensers or [],
+        data=dispensers,
     )

--- a/app/api/routers/beer_types/query_routers.py
+++ b/app/api/routers/beer_types/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.beer_type_composite import beer_type_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import BeerTypeResponse, BeerTypeListResponse
 from app.crud.beer_types import BeerTypeServices
 from app.crud.companies.schemas import CompanyInDB
@@ -35,9 +36,12 @@ async def get_beer_types(
     services: BeerTypeServices = Depends(beer_type_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    beer_types = await services.search_all(company_id=str(company.id))
+    try:
+        beer_types = await services.search_all(company_id=str(company.id))
+    except NotFoundError:
+        beer_types = []
     return build_response(
         status_code=200,
         message="Beer types found with success",
-        data=beer_types or [],
+        data=beer_types,
     )

--- a/app/api/routers/companies/query_routers.py
+++ b/app/api/routers/companies/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.company_composite import company_composer
 from app.api.dependencies import build_response, require_company_member, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import CompanyResponse, CompanyListResponse, SubscriptionResponse
 from app.crud.companies.services import CompanyServices
 from app.crud.companies.schemas import CompanyInDB
@@ -50,7 +51,10 @@ async def get_companies(
     company_services: CompanyServices = Depends(company_composer),
     _: CompanyInDB = Depends(require_user_company),
 ):
-    companies = await company_services.search_all()
+    try:
+        companies = await company_services.search_all()
+    except NotFoundError:
+        companies = []
     return build_response(
-        status_code=200, message="Companies found with success", data=companies or []
+        status_code=200, message="Companies found with success", data=companies
     )

--- a/app/api/routers/customers/query_routers.py
+++ b/app/api/routers/customers/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.customer_composite import customer_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import CustomerResponse, CustomerListResponse
 from app.crud.customers import CustomerServices
 from app.crud.companies.schemas import CompanyInDB
@@ -35,9 +36,12 @@ async def get_customers(
     customer_services: CustomerServices = Depends(customer_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    customers = await customer_services.search_all(company_id=str(company.id))
+    try:
+        customers = await customer_services.search_all(company_id=str(company.id))
+    except NotFoundError:
+        customers = []
     return build_response(
         status_code=200,
         message="Customers found with success",
-        data=customers or [],
+        data=customers,
     )

--- a/app/api/routers/dashboard/query_routers.py
+++ b/app/api/routers/dashboard/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.dashboard_composite import dashboard_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.routers.reservations.schemas import ReservationListResponse
+from app.core.exceptions import NotFoundError
 from app.crud.dashboard.services import DashboardServices
 from app.crud.companies.schemas import CompanyInDB
 
@@ -39,11 +40,16 @@ async def get_upcoming_reservations(
     services: DashboardServices = Depends(dashboard_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    reservations = await services.upcoming_reservations(company_id=str(company.id))
+    try:
+        reservations = await services.upcoming_reservations(
+            company_id=str(company.id)
+        )
+    except NotFoundError:
+        reservations = []
     return build_response(
         status_code=200,
         message="Reservations found with success",
-        data=reservations or [],
+        data=reservations,
     )
 
 

--- a/app/api/routers/extraction_kits/query_routers.py
+++ b/app/api/routers/extraction_kits/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.extraction_kit_composite import extraction_kit_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from app.crud.companies.schemas import CompanyInDB
 from app.crud.extraction_kits import ExtractionKitServices
 
@@ -36,9 +37,12 @@ async def get_extraction_kits(
     services: ExtractionKitServices = Depends(extraction_kit_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    gauges = await services.search_all(company_id=str(company.id))
+    try:
+        gauges = await services.search_all(company_id=str(company.id))
+    except NotFoundError:
+        gauges = []
     return build_response(
         status_code=200,
         message="Extraction kits found with success",
-        data=gauges or [],
+        data=gauges,
     )

--- a/app/api/routers/kegs/query_routers.py
+++ b/app/api/routers/kegs/query_routers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 from app.api.composers.keg_composite import keg_composer
 from app.api.dependencies import build_response, require_user_company
 from app.api.shared_schemas.responses import MessageResponse
+from app.core.exceptions import NotFoundError
 from .schemas import KegResponse, KegListResponse
 from app.crud.kegs import KegServices, KegStatus
 from app.crud.companies.schemas import CompanyInDB
@@ -34,7 +35,12 @@ async def get_kegs(
     services: KegServices = Depends(keg_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    kegs = await services.search_all(company_id=str(company.id), status=status)
+    try:
+        kegs = await services.search_all(
+            company_id=str(company.id), status=status
+        )
+    except NotFoundError:
+        kegs = []
     return build_response(
-        status_code=200, message="Kegs found with success", data=kegs or []
+        status_code=200, message="Kegs found with success", data=kegs
     )

--- a/app/api/routers/payments/query_routers.py
+++ b/app/api/routers/payments/query_routers.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 
 from app.api.composers.payment_composite import payment_composer
 from app.api.dependencies import build_response, require_user_company
+from app.core.exceptions import NotFoundError
 from app.crud.payments.services import PaymentServices
 from app.crud.payments.schemas import PaymentStatus
 from app.crud.companies.schemas import CompanyInDB
@@ -19,9 +20,14 @@ async def get_payments(
     services: PaymentServices = Depends(payment_composer),
     company: CompanyInDB = Depends(require_user_company),
 ):
-    payments = await services.search_all(company_id=str(company.id), status=status)
+    try:
+        payments = await services.search_all(
+            company_id=str(company.id), status=status
+        )
+    except NotFoundError:
+        payments = []
     return build_response(
         status_code=200,
         message="Payments found with success",
-        data=payments or [],
+        data=payments,
     )

--- a/app/api/routers/users/query_routers.py
+++ b/app/api/routers/users/query_routers.py
@@ -100,8 +100,11 @@ async def get_users(
     current_user: UserInDB = Security(decode_jwt, scopes=["user:get"]),
     user_services: UserServices = Depends(user_composer),
 ):
-    users = await user_services.search_all()
+    try:
+        users = await user_services.search_all()
+    except NotFoundError:
+        users = []
 
     return build_response(
-        status_code=200, message="Users found with success", data=users or []
+        status_code=200, message="Users found with success", data=users
     )


### PR DESCRIPTION
## Summary
- handle `NotFoundError` in all list endpoints to return HTTP 200 with empty array when no records are found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5b3a0b14832a81402bdbd2080894